### PR TITLE
Fix description about clip_grads

### DIFF
--- a/chainer-natual-language-processing.ipynb
+++ b/chainer-natual-language-processing.ipynb
@@ -377,7 +377,7 @@
     "* `state, loss_i = model.forward_one_step(x_batch, y_batch, state, dropout_ratio=0.5)`は損失と状態を計算しています。ここで過学習を防ぐdropアウトの率も設定可能です。\n",
     "* `if (i + 1) % bprop_len == 0`はどれだけ過去の文字を保持するかを表しています。bprop_lenが大きければ大きいほど過去の文字を保持できますが、メモリ破綻を起こす可能性があるのでタスクによって適切な数値に設定する必要があります。\n",
     "* bprop_lenの詳細について[truncate](http://kiyukuta.github.io/2013/12/09/mlac2013_day9_recurrent_neural_network_language_model.html#recurrent-neural-network)\n",
-    "* `optimizer.clip_grads(grad_clip)`は正則化をかけており、過学習を防いでいます。\n"
+    "* `optimizer.clip_grads(grad_clip)`は勾配（重みの更新幅）の大きさに上限を設けており、重みが爆発するのを防いでいます。\n"
    ]
   },
   {


### PR DESCRIPTION
`clip_grads`は勾配のサイズに上限を設けるメソッドです。これは、勾配が大きすぎるときに、重みが爆発することがあるので、それを防ぐためです。正則化は`weight_decay`がL2正則化に対応します。
